### PR TITLE
error

### DIFF
--- a/de/lang.php
+++ b/de/lang.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * German language file for cookielaw plugin
+ *
+ * @author Django <django@nausch.org>
+ */
+
+// custom language strings for the plugin
+$lang['information'] = 'Cookies helfen bei der Bereitstellung von Inhalten. ' .
+        'Durch die Nutzung dieser Seiten erklären Sie sich einverstanden, dass Cookies auf Ihrem Rechner gespeichert werden. ';
+$lang['consent'] = 'OK';
+$lang['details'] = ' Weitere Information';
+$lang['details_url'] = 'https://de.wikipedia.org/wiki/Cookie';
+
+
+
+//Setup VIM: ex: et ts=4 :


### PR DESCRIPTION
Padon, but
file must be named as "lang.php"; 
last version it was named as " lang.php" (without space character)
